### PR TITLE
Updated tool.sh to support coursenames with multiple words

### DIFF
--- a/tool.sh
+++ b/tool.sh
@@ -24,12 +24,12 @@ fi
 courseData="{\"name\":\"$course\"}"
 userData="{\"firstName\":\"$first\",\"lastName\":\"$last\",\"email\":\"$email\",\"userName\":\"$username\",\"role\":\"TEACHER\"}"
 
-docker exec -it -e courseData=$courseData bubify-backend bash -c 'PROTOCOL=http;
+docker exec -it -e courseData="$courseData" bubify-backend bash -c 'PROTOCOL=http;
 if [[ $PRODUCTION = "true" ]]; then
   PROTOCOL="https";
 fi; curl -k -X POST $PROTOCOL://localhost:8900/internal/course    -H "Content-Type: application/json"    -d "$courseData"'
 
-docker exec -it -e userData=$userData bubify-backend bash -c 'PROTOCOL=http;
+docker exec -it -e userData="$userData" bubify-backend bash -c 'PROTOCOL=http;
 if [[ $PRODUCTION = "true" ]]; then
   PROTOCOL="https";
 fi; curl -k -X POST $PROTOCOL://localhost:8900/internal/user    -H "Content-Type: application/json"    -d "$userData"'


### PR DESCRIPTION
This solves Issue #1 by simply adding quotes to ensure docker gets the entire string. Also changed user data to be consistent.

This was indeed a simple bash issue that happens when the docker exec command is run and the stored value is evaluated. If the value has a space is included this thus becomes two strings. Solutions is to simply surround the evaluation with quotes.